### PR TITLE
Fix memory leaks detected by running tests with AddressSanitizer

### DIFF
--- a/src/JsEngine.cpp
+++ b/src/JsEngine.cpp
@@ -82,8 +82,9 @@ namespace
     ScopedV8Isolate()
     {
       V8Initializer::Init();
+      allocator.reset(v8::ArrayBuffer::Allocator::NewDefaultAllocator());
       v8::Isolate::CreateParams isolateParams;
-      isolateParams.array_buffer_allocator = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+      isolateParams.array_buffer_allocator = allocator.get();
       isolate = v8::Isolate::New(isolateParams);
     }
 
@@ -101,6 +102,7 @@ namespace
     ScopedV8Isolate(const ScopedV8Isolate&);
     ScopedV8Isolate& operator=(const ScopedV8Isolate&);
 
+    std::unique_ptr<v8::ArrayBuffer::Allocator> allocator;
     v8::Isolate* isolate;
   };
 }

--- a/src/JsEngine.cpp
+++ b/src/JsEngine.cpp
@@ -270,12 +270,10 @@ AdblockPlus::JsValue AdblockPlus::JsEngine::NewCallback(
 {
   const JsContext context(*this);
   auto isolate = GetIsolate();
-  // Note: we are leaking this weak pointer, no obvious way to destroy it when
-  // it's no longer used
-  std::weak_ptr<JsEngine>* data =
-      new std::weak_ptr<JsEngine>(shared_from_this());
+  // The callback may not outlive us since it lives out of our isolate.
+  // It's safe to bind a bare pointer to self.
   v8::Local<v8::FunctionTemplate> templ = v8::FunctionTemplate::New(isolate, callback,
-      v8::External::New(isolate, data));
+      v8::External::New(isolate, this));
   return JsValue(shared_from_this(),
       CHECKED_TO_LOCAL(isolate, templ->GetFunction(isolate->GetCurrentContext())));
 }
@@ -284,12 +282,8 @@ AdblockPlus::JsEnginePtr AdblockPlus::JsEngine::FromArguments(const v8::Function
 {
   const v8::Local<const v8::External> external =
       v8::Local<const v8::External>::Cast(arguments.Data());
-  std::weak_ptr<JsEngine>* data =
-      static_cast<std::weak_ptr<JsEngine>*>(external->Value());
-  JsEnginePtr result = data->lock();
-  if (!result)
-    throw std::runtime_error("Oops, our JsEngine is gone, how did that happen?");
-  return result;
+  JsEngine* engine = static_cast<JsEngine*>(external->Value());
+  return engine->GetSharedPtr();
 }
 
 JsEngine::JsWeakValuesID JsEngine::StoreJsValues(const JsValueList& values)


### PR DESCRIPTION
Two memory leaks were found when running tests built with asan.